### PR TITLE
Fix: Automatic sidebar collapse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added an unread count for new newsletter posts.
+- Added automatic sidebar collapse when window is too small.
 
 ### Changed
 

--- a/app/src/ui/js/sidebar.js
+++ b/app/src/ui/js/sidebar.js
@@ -19,6 +19,7 @@ const SIDEBAR_WIDTH_KEY = "weekbox_sidebar_width";
 const SIDEBAR_COLLAPSED_KEY = "weekbox_sidebar_collapsed";
 const MIN_SIDEBAR_WIDTH = 200;
 const MAX_SIDEBAR_WIDTH = 500;
+const RESPONSIVE_BREAKPOINT = MAX_SIDEBAR_WIDTH * 1.55;
 const sectionResizerControllers = new WeakMap();
 
 export const sidebar = {
@@ -73,6 +74,22 @@ export const sidebar = {
     };
     networkStatus.addEventListener("change", this.networkStatusListener);
     void this.refreshNetworkFeatures();
+    this.setupResponsiveCollapse();
+  },
+  setupResponsiveCollapse() {
+    const updateCollapse = () => {
+      const windowWidth = window.innerWidth;
+      const shouldCollapse = windowWidth <= RESPONSIVE_BREAKPOINT;
+      const isCollapsed = this.sidebar.classList.contains("sidebar--collapsed");
+      if (shouldCollapse && !isCollapsed) {
+        this.setCollapsed(true);
+      }
+      if (this.collapseBtn) {
+        this.collapseBtn.style.display = shouldCollapse ? "none" : "";
+      }
+    };
+    updateCollapse();
+    window.addEventListener("resize", updateCollapse);
   },
   setupResizer() {
     if (!this.resizer) return;


### PR DESCRIPTION
## Summary

- Added automatic sidebar collapse when window is too small. 

## Changes
- Added new functions in `sidebar.js` - `setupResponsiveCollapse` and `updateCollaps`.
- `RESPONSIVE_BREAKPOINT` is const value in `sidebar.js`, responsible for sidebar collapse break-point.
- When window width will be small enough (listened by event on "resize"), it will call `setCollapsed(true)` and disable `collapseBtn` in order to not make text overflow appear after button press.
- When window width become bigger, `collapseBtn` will be enabled again.

## Testing

- [x] `npm run build`
- [x] Manual testing completed where applicable.

## Checklist

- [x] I kept this pull request focused.
- [x] I updated documentation when needed.
- [x] I updated `CHANGELOG.md` when the change affects users or contributors.
- [x] I did not include secrets or unrelated changes.
- [x] I followed the repository's contribution guide.
- [x] My commits follow Conventional Commits.

## Screenshots or recordings

Before:

https://github.com/user-attachments/assets/410419d7-5030-4bd8-90e2-b2d4ab7eb6b4

After:

https://github.com/user-attachments/assets/9c589e41-ab44-4205-bf96-f91fed26e52d


